### PR TITLE
Add missing comma in _interpret_common_properties

### DIFF
--- a/mf2util.py
+++ b/mf2util.py
@@ -535,7 +535,7 @@ def _interpret_common_properties(
     result = {}
     props = hentry['properties']
 
-    for prop in ('url', 'uid', 'photo', 'featured' 'logo'):
+    for prop in ('url', 'uid', 'photo', 'featured', 'logo'):
         value = get_plain_text(props.get(prop))
         if value:
             result[prop] = value


### PR DESCRIPTION
I think there's a missing comma between featured and logo in _interpret_common_properties 